### PR TITLE
Strip off ANSI colored maven output from deps lines

### DIFF
--- a/lib/jars/installer.rb
+++ b/lib/jars/installer.rb
@@ -40,6 +40,10 @@ module Jars
         setup_type(line)
 
         line.strip!
+
+        # strip off trailing module output (jruby/jar-dependencies#92)
+        line.sub!(/\u001B.*$/, EMPTY)
+
         @coord = line.sub(/:[^:]+:([A-Z]:\\)?[^:]+$/, EMPTY)
         first, second = @coord.split(/:#{type}:/)
         group_id, artifact_id = first.split(':')

--- a/specs/dependency_spec.rb
+++ b/specs/dependency_spec.rb
@@ -2,7 +2,7 @@
 
 require File.expand_path('setup', File.dirname(__FILE__))
 
-require 'jar_installer'
+require 'jars/installer'
 
 # rubocop:disable Layout/LineLength
 describe Jars::Installer::Dependency do

--- a/specs/jar_installer_spec.rb
+++ b/specs/jar_installer_spec.rb
@@ -2,7 +2,7 @@
 
 require File.expand_path('setup', File.dirname(__FILE__))
 
-require 'jar_installer'
+require 'jars/installer'
 require 'fileutils'
 require 'rubygems/specification'
 


### PR DESCRIPTION
This extra output got included in the filename and breaks installation of jars on platforms where the output gets included. This includes at least Linux, but I have been unable to reproduce on MacOS so far. This is a stopgap until I can figure out why this output is happening and fully disable it.

The regexp matching in this method could also be improved to avoid breaking on future format changes.

Fixes jruby/jar-dependencies#92.

See also jruby/jruby#8606.