### PR TITLE
Simplify parse of dependency line

### DIFF
--- a/lib/jars/installer.rb
+++ b/lib/jars/installer.rb
@@ -37,12 +37,13 @@ module Jars
       REG = /:jar:|:pom:|:test:|:compile:|:runtime:|:provided:|:system:/.freeze
       EMPTY = ''
       def initialize(line)
+        # remove ANSI escape sequences and module section (https://issues.apache.org/jira/browse/MDEP-974)
+        line = line.gsub(/\e\[\d*m/, '')
+        line = line.gsub(/ -- module.*/, '')
+
         setup_type(line)
 
         line.strip!
-
-        # strip off trailing module output (jruby/jar-dependencies#92)
-        line.sub!(/\u001B.*$/, EMPTY)
 
         @coord = line.sub(/:[^:]+:([A-Z]:\\)?[^:]+$/, EMPTY)
         first, second = @coord.split(/:#{type}:/)

--- a/specs/dependency_spec.rb
+++ b/specs/dependency_spec.rb
@@ -89,5 +89,27 @@ describe Jars::Installer::Dependency do
     _(dep.path).must_equal 'org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0-no_aop.jar'
     _(dep.file).must_equal 'C:\\Users\\Local\\repository\\org\\sonatype\\sisu\\sisu-guice\\3.1.0\\sisu-guice-3.1.0-no_aop.jar'
   end
+
+  # these next two combine every possible oddity to try to cover all combinations (classifier, windows path, ANSI and module)
+
+  it 'should parse dependency with module section' do
+    dep = Jars::Installer::Dependency.new(+'   org.eclipse.sisu:org.eclipse.sisu.plexus:jar:no_aop:0.0.0.M2a:compile:C:\\Users\\Local\\repository\\org\\sonatype\\sisu\\org.eclipse.sisu.plexus\\0.0.0.M2a\\org.eclipse.sisu.plexus-0.0.0.M2a-no_aop.jar -- module org.sonatype.sisu.sisu-guice')
+    _(dep.type).must_equal :jar
+    _(dep.scope).must_equal :runtime
+    _(dep.gav).must_equal 'org.eclipse.sisu:org.eclipse.sisu.plexus:no_aop:0.0.0.M2a'
+    _(dep.coord).must_equal 'org.eclipse.sisu:org.eclipse.sisu.plexus:jar:no_aop:0.0.0.M2a'
+    _(dep.path).must_equal 'org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M2a/org.eclipse.sisu.plexus-0.0.0.M2a-no_aop.jar'
+    _(dep.file).must_equal 'C:\\Users\\Local\\repository\\org\\sonatype\\sisu\\org.eclipse.sisu.plexus\\0.0.0.M2a\\org.eclipse.sisu.plexus-0.0.0.M2a-no_aop.jar'
+  end
+
+  it 'should parse dependency with ANSI-colored module section' do
+    dep = Jars::Installer::Dependency.new(+"   org.eclipse.sisu:org.eclipse.sisu.plexus:jar:no_aop:0.0.0.M2a:compile:C:\\Users\\Local\\repository\\org\\sonatype\\sisu\\org.eclipse.sisu.plexus\\0.0.0.M2a\\org.eclipse.sisu.plexus-0.0.0.M2a-no_aop.jar\e[31m -- module org.sonatype.sisu.sisu-guice\e[m")
+    _(dep.type).must_equal :jar
+    _(dep.scope).must_equal :runtime
+    _(dep.gav).must_equal 'org.eclipse.sisu:org.eclipse.sisu.plexus:no_aop:0.0.0.M2a'
+    _(dep.coord).must_equal 'org.eclipse.sisu:org.eclipse.sisu.plexus:jar:no_aop:0.0.0.M2a'
+    _(dep.path).must_equal 'org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M2a/org.eclipse.sisu.plexus-0.0.0.M2a-no_aop.jar'
+    _(dep.file).must_equal 'C:\\Users\\Local\\repository\\org\\sonatype\\sisu\\org.eclipse.sisu.plexus\\0.0.0.M2a\\org.eclipse.sisu.plexus-0.0.0.M2a-no_aop.jar'
+  end
 end
 # rubocop:enable Layout/LineLength


### PR DESCRIPTION
This is a more robust way to tidy up the lines emitted by dependency:list as reported in #92 and quickly fixed in #93.

I also added tests for the module section with and without ANSI.